### PR TITLE
Mouse Anchor and Smart Anchor tooltip behavior

### DIFF
--- a/options/options.lua
+++ b/options/options.lua
@@ -109,6 +109,8 @@
             MODUI_VAR['elements']['nameplate'].totem            = true
             MODUI_VAR['elements']['tracker'].enable             = true
             MODUI_VAR['elements']['tooltip'].enable             = true
+			MODUI_VAR['elements']['tooltip'].smartanchor		= true
+			MODUI_VAR['elements']['tooltip'].mouseanchor		= true
             MODUI_VAR['elements']['unit'].enable                = true
             MODUI_VAR['elements']['unit'].player                = true
             MODUI_VAR['elements']['unit'].target                = true
@@ -456,11 +458,40 @@
             function(self)
                 MODUI_VAR['elements']['tooltip'].enable = self:GetChecked() and true or false
                 ShowReload()
+				ToggleChildButton(
+					self,
+					{
+						_G['modui_checkbutton23'],
+						_G['modui_checkbutton24'],
+					}
+				)
             end,
             MODUI_VAR['elements']['tooltip'].enable and true or false,
             1, .8, 0,
             nil,
             true
+        )
+		add(
+            'Smart Anchor',
+            function(self)
+                MODUI_VAR['elements']['tooltip'].smartanchor = self:GetChecked() and true or false
+                ShowReload()
+            end,
+            MODUI_VAR['elements']['tooltip'].smartanchor and true or false,
+            1, 1, 1,
+            true,
+            MODUI_VAR['elements']['tooltip'].enable and true or false
+        )
+        add(
+            'Mouse Anchor',
+            function(self)
+                MODUI_VAR['elements']['tooltip'].mouseanchor = self:GetChecked() and true or false
+                ShowReload()
+            end,
+            MODUI_VAR['elements']['tooltip'].mouseanchor and true or false,
+            1, 1, 1,
+            true,
+            MODUI_VAR['elements']['tooltip'].enable and true or false
         )
         add(
             'Unitframes',
@@ -470,7 +501,6 @@
                 ToggleChildButton(
                     self,
                     {
-                        _G['modui_checkbutton23'],
                         _G['modui_checkbutton24'],
                         _G['modui_checkbutton25'],
                         _G['modui_checkbutton26'],
@@ -478,6 +508,7 @@
                         _G['modui_checkbutton28'],
                         _G['modui_checkbutton29'],
                         _G['modui_checkbutton30'],
+                        _G['modui_checkbutton31'],
                     }
                 )
             end,

--- a/options/options.lua
+++ b/options/options.lua
@@ -461,8 +461,8 @@
 				ToggleChildButton(
 					self,
 					{
+						_G['modui_checkbutton22'],
 						_G['modui_checkbutton23'],
-						_G['modui_checkbutton24'],
 					}
 				)
             end,
@@ -501,7 +501,6 @@
                 ToggleChildButton(
                     self,
                     {
-                        _G['modui_checkbutton24'],
                         _G['modui_checkbutton25'],
                         _G['modui_checkbutton26'],
                         _G['modui_checkbutton27'],
@@ -509,6 +508,7 @@
                         _G['modui_checkbutton29'],
                         _G['modui_checkbutton30'],
                         _G['modui_checkbutton31'],
+                        _G['modui_checkbutton32'],
                     }
                 )
             end,

--- a/tooltip/layout.lua
+++ b/tooltip/layout.lua
@@ -149,7 +149,7 @@
             hooksecurefunc('GameTooltip_SetDefaultAnchor',  AddAnchor)
 			--OnUpdate hook for mouseanchor
 			if MODUI_VAR['elements']['tooltip'].mouseanchor then
-				hooksecurefunc('GameTooltip_OnUpdate', MouseUpdate)
+				GameTooltip:HookScript('OnUpdate', MouseUpdate)
 			end
 			
         end

--- a/tooltip/layout.lua
+++ b/tooltip/layout.lua
@@ -80,14 +80,40 @@
     end
 
     local AddAnchor = function(tooltip, parent)
-        if  not GetMouseoverUnit() then
-            tooltip:SetOwner(parent, 'ANCHOR_CURSOR')
-        else
-            tooltip:ClearAllPoints()
-            tooltip:SetPoint('BOTTOMRIGHT', UIParent, -33, 33)
-            AddStatusBar(GameTooltipStatusBar, tooltip, false)
-        end
-    end
+		--MouseAnchor behavior below
+		if MODUI_VAR['elements']['tooltip'].mouseanchor then
+			--SmartAnchor behavior here
+			if GetMouseFocus() ~= WorldFrame and MODUI_VAR['elements']['tooltip'].smartanchor then
+				tooltip:ClearAllPoints()
+				tooltip:SetOwner(parent, "ANCHOR_TOP", 0, 10)
+				return
+			end		
+				local x, y = GetCursorPosition()
+				local effScale = tooltip:GetEffectiveScale()
+				tooltip:ClearAllPoints()
+				tooltip:SetPoint("TOPLEFT", UIParent, "BOTTOMLEFT", (x / effScale + 25), (y / effScale + -25))
+		else
+		--Standard modui behavior below
+			if  not GetMouseoverUnit() then
+				tooltip:SetOwner(parent, 'ANCHOR_CURSOR')
+			else
+				tooltip:ClearAllPoints()
+				tooltip:SetPoint('BOTTOMRIGHT', UIParent, -33, 33)
+				AddStatusBar(GameTooltipStatusBar, tooltip, false)
+			end
+		end
+	end
+
+	local MouseUpdate = function(tooltip, parent)
+		--Don't follow if we aren't in the WorldFrame as it's irritating.
+		if GetMouseFocus() ~= WorldFrame then
+			return
+		end		
+		local x, y = GetCursorPosition()
+		local effScale = tooltip:GetEffectiveScale()
+		tooltip:ClearAllPoints()
+		tooltip:SetPoint("TOPLEFT", UIParent, "BOTTOMLEFT", (x / effScale + 25), (y / effScale + -25))
+	end
 
     local UpdateStyle = function(self)
         local _, link = self:GetItem()
@@ -121,6 +147,11 @@
             hooksecurefunc('GameTooltip_UpdateStyle',       UpdateStyle)
             hooksecurefunc('GameTooltip_SetBackdropStyle',  UpdateStyle)
             hooksecurefunc('GameTooltip_SetDefaultAnchor',  AddAnchor)
+			--OnUpdate hook for mouseanchor
+			if MODUI_VAR['elements']['tooltip'].mouseanchor then
+				hooksecurefunc('GameTooltip_OnUpdate', MouseUpdate)
+			end
+			
         end
     end
 


### PR DESCRIPTION
This tooltip addition allows the tooltip to follow the mouse cursor on WorldFrame. If the cursor enters a frame, and SmartAnchor is enabled - the tooltip will anchor 10 pixels above the frame, creating a nice stable reading position. Currently the SmartAnchor feature is dependent on MouseAnchor being enabled. The two features could be made separate, or maybe it's redundant to separate them at all, and it should all just be referred to as "Smart Anchor"