### PR TITLE
+ Toggle chat names by class color

### DIFF
--- a/chat/chat.lua
+++ b/chat/chat.lua
@@ -31,6 +31,11 @@
     end
 
     local AddChat = function()
+        if  MODUI_VAR['elements']['chat'].enable and  MODUI_VAR['elements']['chat'].colornames then
+            SetCVar("chatClassColorOverride", 0)
+        else
+            SetCVar("chatClassColorOverride", 1)
+        end
         ChatFrameChannelButton:ClearAllPoints()
         ChatFrameChannelButton:SetPoint('BOTTOM', ChatFrame1ButtonFrame, 0, 22)
 

--- a/core/var.lua
+++ b/core/var.lua
@@ -25,6 +25,7 @@
 				style			= true,
 				url				= true,
 				sysmsg			= false, -- objective text goes in chat window
+				colornames      = true,
 			},
 			ecastbar = {
 				enable			= true,

--- a/options/options.lua
+++ b/options/options.lua
@@ -100,6 +100,7 @@
             MODUI_VAR['elements']['chat'].events                = true
             MODUI_VAR['elements']['chat'].style                 = true
             MODUI_VAR['elements']['chat'].url                   = true
+            MODUI_VAR['elements']['chat'].colornames            = true
             MODUI_VAR['elements']['onebag'].enable              = true
             MODUI_VAR['elements']['onebag'].greys               = true
             MODUI_VAR['elements']['ecastbar'].enable            = true
@@ -135,6 +136,7 @@
             MODUI_VAR['elements']['chat'].events                = false
             MODUI_VAR['elements']['chat'].style                 = false
             MODUI_VAR['elements']['chat'].url                   = false
+            MODUI_VAR['elements']['chat'].colornames            = false
             MODUI_VAR['elements']['onebag'].enable              = false
             MODUI_VAR['elements']['onebag'].greys               = false
             MODUI_VAR['elements']['ecastbar'].enable            = false
@@ -320,6 +322,7 @@
                         _G['modui_checkbutton10'],
                         _G['modui_checkbutton11'],
                         _G['modui_checkbutton12'],
+                        _G['modui_checkbutton13'],
                     }
                 )
             end,
@@ -346,6 +349,17 @@
                 ShowReload()
             end,
             MODUI_VAR['elements']['chat'].style and true or false,
+            1, 1, 1,
+            true,
+            MODUI_VAR['elements']['chat'].enable and true or false
+        )
+        add(
+            'Chat Color Names by Class',
+            function(self)
+                MODUI_VAR['elements']['chat'].colornames = self:GetChecked() and true or false
+                ShowReload()
+            end,
+            MODUI_VAR['elements']['chat'].colornames and true or false,
             1, 1, 1,
             true,
             MODUI_VAR['elements']['chat'].enable and true or false


### PR DESCRIPTION
Add the option to render names in the Chat frame by class.

<img width="1680" alt="Screenshot 2019-09-05 at 21 32 41" src="https://user-images.githubusercontent.com/823090/64374805-d5731580-d024-11e9-8dc2-d86bd4f9aa72.png">
