### PR TITLE
Fix SendMailItem Tooltip

### DIFF
--- a/tooltip/content.lua
+++ b/tooltip/content.lua
@@ -181,7 +181,7 @@
 
             hooksecurefunc(v, 'SetSendMailItem', function(index)
             	local _, _, count = GetSendMailItem(index)
-                AddPrice(count)
+                AddPrice(self, count)
             end)
 
             hooksecurefunc(v, 'SetTradePlayerItem', function(self, index)


### PR DESCRIPTION
Fixes #72 
Missing `self, ` in `AddPrice` declaration.