### PR TITLE
Hides the XP bar if the player is lvl 60

### DIFF
--- a/actionbar/bars.lua
+++ b/actionbar/bars.lua
@@ -354,6 +354,16 @@
         hooksecurefunc('ShowPetActionBar', UpdatePetBar)
     end
 
+    local DisableXPBarForMaxLevel = function()
+        local level = UnitLevel("player")
+        if (level == 60)
+            MainMenuMaxLevelBar:Hide()
+            MainMenuMaxLevelBar0:Hide()
+            MainMenuMaxLevelBar1:Hide()
+            MainMenuMaxLevelBar3:Hide()
+        end
+    end
+
     local OnEvent = function(self, event)
         if  MODUI_VAR['elements']['mainbar'].enable then
             if  event == 'PLAYER_LOGIN' then
@@ -361,8 +371,10 @@
                 AddButtonSkin()
                 MoveBars()
                 UpdateBars()
+                DisableXPBarForMaxLevel()
             else
                 UpdateXP()
+                DisableXPBarForMaxLevel()
             end
         elseif MODUI_VAR['elements']['mainbar'].xp then
             AddXP()

--- a/actionbar/bars.lua
+++ b/actionbar/bars.lua
@@ -356,10 +356,9 @@
 
     local DisableXPBarForMaxLevel = function()
         local level = UnitLevel("player")
-        if (level == 60)
-            MainMenuMaxLevelBar:Hide()
+        if level == 60 then
             MainMenuMaxLevelBar0:Hide()
-            MainMenuMaxLevelBar1:Hide()
+            MainMenuMaxLevelBar2:Hide()
             MainMenuMaxLevelBar3:Hide()
         end
     end
@@ -374,7 +373,6 @@
                 DisableXPBarForMaxLevel()
             else
                 UpdateXP()
-                DisableXPBarForMaxLevel()
             end
         elseif MODUI_VAR['elements']['mainbar'].xp then
             AddXP()


### PR DESCRIPTION
So I'm quite new to the modding scene, and not used to lua coding. 

I added a simple function that checks if the player is lvl 60, and if true then it disables the XP bar as described in https://github.com/obble/modui_classic/issues/77.