### PR TITLE
Disable tooltip fade out option

### DIFF
--- a/core/var.lua
+++ b/core/var.lua
@@ -61,6 +61,7 @@
 			tooltip = {
 				enable			= true,
 				mouseanchor		= false,
+				disablefade		= false,
 			},
 			tracker = {
 				enable 			= true,

--- a/options/options.lua
+++ b/options/options.lua
@@ -113,6 +113,7 @@
             MODUI_VAR['elements']['tooltip'].enable             = true
             MODUI_VAR['elements']['tooltip'].smartanchor		= true
 			MODUI_VAR['elements']['tooltip'].mouseanchor		= true
+			MODUI_VAR['elements']['tooltip'].disablefade		= true
             MODUI_VAR['elements']['unit'].enable                = true
             MODUI_VAR['elements']['unit'].player                = true
             MODUI_VAR['elements']['unit'].target                = true
@@ -149,6 +150,7 @@
             MODUI_VAR['elements']['tooltip'].enable             = false
             MODUI_VAR['elements']['tooltip'].smartanchor		= false
 			MODUI_VAR['elements']['tooltip'].mouseanchor		= false
+            MODUI_VAR['elements']['tooltip'].disablefade		= false
             MODUI_VAR['elements']['unit'].enable                = false
             MODUI_VAR['elements']['unit'].player                = false
             MODUI_VAR['elements']['unit'].target                = false
@@ -416,10 +418,10 @@
                 ToggleChildButton(
                     self,
                     {
-                        _G['modui_checkbutton17'],
                         _G['modui_checkbutton18'],
                         _G['modui_checkbutton19'],
                         _G['modui_checkbutton20'],
+                        _G['modui_checkbutton21'],
                     }
                 )
             end,
@@ -490,7 +492,8 @@
                 ToggleChildButton(
                     self,
                     {
-                        _G['modui_checkbutton23'],
+                        _G['modui_checkbutton24'],
+                        _G['modui_checkbutton25'],
                     }
                 )
             end,
@@ -511,6 +514,17 @@
             MODUI_VAR['elements']['tooltip'].enable and true or false
         )
         add(
+            'Disable fade out',
+            function(self)
+                MODUI_VAR['elements']['tooltip'].disablefade = self:GetChecked() and true or false
+                ShowReload()
+            end,
+            MODUI_VAR['elements']['tooltip'].disablefade and true or false,
+            1, 1, 1,
+            true,
+            MODUI_VAR['elements']['tooltip'].enable and true or false
+        )
+        add(
             'Unitframes',
             function(self)
                 MODUI_VAR['elements']['unit'].enable = self:GetChecked() and true or false
@@ -518,14 +532,14 @@
                 ToggleChildButton(
                     self,
                     {
-                        _G['modui_checkbutton25'],
-                        _G['modui_checkbutton26'],
                         _G['modui_checkbutton27'],
                         _G['modui_checkbutton28'],
                         _G['modui_checkbutton29'],
                         _G['modui_checkbutton30'],
                         _G['modui_checkbutton31'],
                         _G['modui_checkbutton32'],
+                        _G['modui_checkbutton33'],
+                        _G['modui_checkbutton34'],
                     }
                 )
             end,

--- a/tooltip/layout.lua
+++ b/tooltip/layout.lua
@@ -145,7 +145,19 @@
             hooksecurefunc('GameTooltip_SetDefaultAnchor',  AddAnchor)
             if  MODUI_VAR['elements']['tooltip'].mouseanchor then
 				GameTooltip:HookScript('OnUpdate', MouseUpdate)
-			end
+            end
+            if  MODUI_VAR['elements']['tooltip'].disablefade then
+                self.hasUnitTooltip = false
+                self:SetScript('OnUpdate', function(self)
+                    local _, unit = GameTooltip:GetUnit()
+                    if self.hasUnitTooltip and not unit then
+                        GameTooltip:Hide()
+                        self.hasUnitTooltip = nil
+                    elseif unit then
+                        self.hasUnitTooltip = true
+                    end
+                end)
+            end
         end
     end
 

--- a/tooltip/layout.lua
+++ b/tooltip/layout.lua
@@ -149,11 +149,11 @@
             if  MODUI_VAR['elements']['tooltip'].disablefade then
                 self.hasUnitTooltip = false
                 self:SetScript('OnUpdate', function(self)
-                    local _, unit = GameTooltip:GetUnit()
-                    if self.hasUnitTooltip and not unit then
+                    local mouseoverExists = UnitExists("mouseover")
+                    if self.hasUnitTooltip and not mouseoverExists then
                         GameTooltip:Hide()
                         self.hasUnitTooltip = nil
-                    elseif unit then
+                    elseif not self.hasUnitTooltip and mouseoverExists then
                         self.hasUnitTooltip = true
                     end
                 end)


### PR DESCRIPTION
Adds a option to disable the tooltip fade out when using mouse anchor

Fixes #63 